### PR TITLE
error_handler is fired when DNS resolution fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sleekxmpp.egg-info/
 *~
 .baboon/
 .DS_STORE
+.idea/

--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -481,9 +481,14 @@ class XMLStream(object):
                 self._service_name = host
             except StopIteration:
                 log.debug("No remaining DNS records to try.")
+                # When network connection is restored, DNS resolution still fails so error_handler is fired
+                log.debug("DNS error, firing error callback")
+                self.error_handler.fire()
                 self.dns_answers = None
                 if reattempt:
                     self.reconnect_delay = delay
+                if self.socket:
+                    self.abort()
                 return False
 
         af = Socket.AF_INET


### PR DESCRIPTION
Error handler jest wywoływany tylko przy błędzie DNS